### PR TITLE
feat(addon): pull pre-built image from GHCR + multi-arch standalone

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Build and Push to GHCR
+name: Build and Push Images to GHCR
 
 on:
   release:
@@ -8,10 +8,11 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  OWNER: ${{ github.repository_owner }}
 
 jobs:
-  build-and-push:
+  build-standalone:
+    name: Build standalone (multi-arch)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -21,35 +22,96 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels)
+      - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/meralco-ph
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=
 
-      - name: Build and push Docker image
+      - name: Build and push standalone image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile.standalone
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=standalone
+          cache-to: type=gha,mode=max,scope=standalone
+
+  build-addon:
+    name: Build add-on (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            base: ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.20
+            platform: linux/amd64
+          - arch: aarch64
+            base: ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.20
+            platform: linux/arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.arch }}-meralco-ph
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push add-on image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          build-args: |
+            BUILD_FROM=${{ matrix.base }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=addon-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=addon-${{ matrix.arch }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.2] - 2026-04-22
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Add-on now pulls a pre-built image from GHCR instead of building locally. Installs and updates are faster and the Rebuild button is replaced with Reinstall.
+- Standalone Docker image is now multi-arch (amd64 + aarch64). `docker pull ghcr.io/rairulyle/meralco-ph:latest` works on ARM hosts.
+
 ## [2.0.1] - 2026-04-11
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,22 @@ If the PDF table structure changes (e.g. different row labels or column layout),
 - Include steps to reproduce for bug reports.
 - Check existing issues before opening a new one.
 
+## Release flow (maintainer)
+
+Releases are tag-driven. The `docker-publish.yml` workflow triggers on `v*` tag pushes and publishes three images to GHCR: `meralco-ph` (multi-arch standalone), `amd64-meralco-ph` and `aarch64-meralco-ph` (HA add-on per-arch).
+
+The add-on's `config.yaml` uses `image: ghcr.io/rairulyle/{arch}-meralco-ph`, so HA Supervisor pulls the tag matching `version:`. That tag must exist on GHCR before users can install or update.
+
+To cut a release:
+
+1. On a branch, bump `version:` in `config.yaml` and update `CHANGELOG.md`.
+2. Merge the branch into `main`.
+3. Tag `main` with `vX.Y.Z` (matching the new version) and push the tag.
+4. Wait for CI to finish publishing all three images.
+5. Users see the new version in the HA add-on store or via `docker pull`.
+
+Steps 2 and 3 must be in that order. If you tag before merging, the workflow builds the old code under the new tag.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # ⚡ MERALCO PH - API
 
+[![GitHub Release][releases-shield]][releases]
+[![License][license-shield]][license]
+
+![Supports amd64 Architecture][amd64-shield]
+![Supports aarch64 Architecture][aarch64-shield]
+
+[![Build Status][github-actions-shield]][github-actions]
+![Project Maintenance][maintenance-shield]
+[![GitHub Activity][commits-shield]][commits]
+
+[![Buy Me a Coffee][bmc-shield]][bmc]
+
 Konnichiwassup! This is a REST API that provides current MERALCO (Manila Electric Company) electricity rates in the Philippines.
 
 MERALCO is the largest electric distribution utility company in the Philippines, serving Metro Manila and nearby provinces. This API automatically parses MERALCO's monthly residential bills and serves per-kWh rates at every consumption level they publish. Rates match MERALCO's published [typical household article](https://company.meralco.com.ph/news-and-advisories/higher-residential-rates-april-2026).
@@ -233,3 +245,17 @@ MIT License, see [LICENSE](LICENSE) for details.
 ---
 
 **Keywords:** MERALCO rates, Philippines electricity rates, Philippine power rates, Manila Electric Company, MERALCO kWh rate, Philippine electricity price, Home Assistant MERALCO integration, MERALCO API, MERALCO Docker
+
+[releases-shield]: https://img.shields.io/github/v/release/rairulyle/meralco-ph
+[releases]: https://github.com/rairulyle/meralco-ph/releases
+[license-shield]: https://img.shields.io/github/license/rairulyle/meralco-ph
+[license]: https://github.com/rairulyle/meralco-ph/blob/main/LICENSE
+[amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
+[aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
+[github-actions-shield]: https://img.shields.io/github/actions/workflow/status/rairulyle/meralco-ph/docker-publish.yml
+[github-actions]: https://github.com/rairulyle/meralco-ph/actions
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2026
+[commits-shield]: https://img.shields.io/github/commit-activity/m/rairulyle/meralco-ph
+[commits]: https://github.com/rairulyle/meralco-ph/commits/main
+[bmc-shield]: https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black
+[bmc]: https://buymeacoffee.com/rairulyle

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ version: "2.0.2"
 slug: meralco-ph
 description: Parses MERALCO's official residential bills PDF and exposes per-kWh rates via MQTT discovery or REST API.
 url: "https://github.com/rairulyle/meralco-ph"
+image: ghcr.io/rairulyle/{arch}-meralco-ph
 arch:
   - amd64
   - aarch64

--- a/src/api.py
+++ b/src/api.py
@@ -169,7 +169,7 @@ def index() -> ResponseReturnValue:
     return jsonify(
         {
             "service": "MERALCO API",
-            "version": "2.0.0",
+            "version": "2.0.2",
             "endpoints": {
                 "/rates": "Get all consumption-level rates",
                 "/rates/typical": "Get typical household (200 kWh) rate",


### PR DESCRIPTION
## Summary

- HA add-on now pulls pre-built images from GHCR (`{arch}-meralco-ph`) instead of building locally, so the Rebuild button is replaced with Reinstall and installs count toward GHCR download stats.
- Standalone Docker image at `ghcr.io/rairulyle/meralco-ph` is now multi-arch (amd64 + arm64), so ARM hosts can `docker pull` it.
- CI workflow rewritten to publish three GHCR packages on every `v*` tag: multi-arch standalone + per-arch (amd64, aarch64) add-on images.
- README shields + Buy Me a Coffee. CONTRIBUTING release flow. CHANGELOG Unreleased entry.

No changes to `src/`, `Dockerfile`, `Dockerfile.standalone`, `build.yaml`, or `rootfs/`. `config.yaml` version stays at 2.0.2.

## Test plan

- [x] 75/75 unit tests pass locally (`PYTHONPATH=. pytest tests/ -q`)
- [x] YAML lint passes for `config.yaml` and `.github/workflows/docker-publish.yml`
- [x] Workflow matrix base images match `build.yaml` for amd64 and aarch64