### PR TITLE
feat(ci): publish add-on as single multi-arch image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -58,22 +58,11 @@ jobs:
           cache-to: type=gha,mode=max,scope=standalone
 
   build-addon:
-    name: Build add-on (${{ matrix.arch }})
+    name: Build add-on (multi-arch)
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            base: ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.20
-            platform: linux/amd64
-          - arch: aarch64
-            base: ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.20
-            platform: linux/arm64
 
     steps:
       - name: Checkout repository
@@ -96,22 +85,23 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.arch }}-meralco-ph
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/meralco-ph-addon
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=Home Assistant Add-on: MERALCO Electricity Rates
+            org.opencontainers.image.description=Parses MERALCO's residential bills PDF and exposes per-kWh rates via MQTT or REST
 
       - name: Build and push add-on image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           push: true
-          build-args: |
-            BUILD_FROM=${{ matrix.base }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=addon-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=addon-${{ matrix.arch }}
+          cache-from: type=gha,scope=addon
+          cache-to: type=gha,mode=max,scope=addon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Add-on image is now a single multi-arch package (`meralco-ph-addon`) replacing the per-arch `amd64-meralco-ph` and `aarch64-meralco-ph` packages.
+
 ## [2.0.2] - 2026-04-22
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,16 +57,16 @@ If the PDF table structure changes (e.g. different row labels or column layout),
 
 ## Release flow (maintainer)
 
-Releases are tag-driven. The `docker-publish.yml` workflow triggers on `v*` tag pushes and publishes three images to GHCR: `meralco-ph` (multi-arch standalone), `amd64-meralco-ph` and `aarch64-meralco-ph` (HA add-on per-arch).
+Releases are tag-driven. The `docker-publish.yml` workflow triggers on `v*` tag pushes and publishes two multi-arch images (amd64 + aarch64) to GHCR: `meralco-ph` (standalone) and `meralco-ph-addon` (HA add-on).
 
-The add-on's `config.yaml` uses `image: ghcr.io/rairulyle/{arch}-meralco-ph`, so HA Supervisor pulls the tag matching `version:`. That tag must exist on GHCR before users can install or update.
+The add-on's `config.yaml` uses `image: ghcr.io/rairulyle/meralco-ph-addon`, so HA Supervisor pulls the tag matching `version:`. That tag must exist on GHCR before users can install or update.
 
 To cut a release:
 
 1. On a branch, bump `version:` in `config.yaml` and update `CHANGELOG.md`.
 2. Merge the branch into `main`.
 3. Tag `main` with `vX.Y.Z` (matching the new version) and push the tag.
-4. Wait for CI to finish publishing all three images.
+4. Wait for CI to finish publishing both images.
 5. Users see the new version in the HA add-on store or via `docker pull`.
 
 Steps 2 and 3 must be in that order. If you tag before merging, the workflow builds the old code under the new tag.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-ARG BUILD_FROM
-FROM ${BUILD_FROM}
+# check=skip=InvalidBaseImagePlatform
+
+# HA base images are published per-arch as `amd64-…` / `aarch64-…` with no
+# generic multi-arch manifest, so map buildx's TARGETARCH (amd64 / arm64)
+# onto the matching base via stage aliases. Only the selected stage is pulled.
+FROM ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.20 AS base-amd64
+FROM ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.20 AS base-arm64
+
+ARG TARGETARCH
+FROM base-${TARGETARCH}
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ MERALCO is the largest electric distribution utility company in the Philippines,
 
 The easiest way to use MERALCO PH with Home Assistant. Install the add-on and sensor entities are created automatically via MQTT discovery, no manual `configuration.yaml` editing needed.
 
-[Add repository to my Home Assistant](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Frairulyle%2Fmeralco-ph)
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.][repository-badge]][repository-url]
 
 ### Prerequisites
 
@@ -255,3 +255,5 @@ MIT License, see [LICENSE](LICENSE) for details.
 [commits]: https://github.com/rairulyle/meralco-ph/commits/main
 [bmc-shield]: https://img.shields.io/badge/Buy%20Me%20a%20Coffee-FFDD00?logo=buymeacoffee&logoColor=black
 [bmc]: https://buymeacoffee.com/rairulyle
+[repository-badge]: https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg
+[repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Frairulyle%2Fmeralco-ph

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,0 @@
-build_from:
-  amd64: "ghcr.io/home-assistant/amd64-base-python:3.12-alpine3.20"
-  aarch64: "ghcr.io/home-assistant/aarch64-base-python:3.12-alpine3.20"
-labels:
-  org.opencontainers.image.title: "Home Assistant Add-on: MERALCO Electricity Rates"
-  org.opencontainers.image.description: "Parses MERALCO's residential bills PDF and exposes per-kWh rates via MQTT or REST"
-  org.opencontainers.image.source: "https://github.com/rairulyle/meralco-ph"
-  org.opencontainers.image.licenses: "MIT"

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ version: "2.0.2"
 slug: meralco-ph
 description: Parses MERALCO's official residential bills PDF and exposes per-kWh rates via MQTT discovery or REST API.
 url: "https://github.com/rairulyle/meralco-ph"
-image: ghcr.io/rairulyle/{arch}-meralco-ph
+image: ghcr.io/rairulyle/meralco-ph-addon
 arch:
   - amd64
   - aarch64


### PR DESCRIPTION
## Why

The HA add-on currently publishes two per-arch GHCR packages (`amd64-meralco-ph`, `aarch64-meralco-ph`) via the legacy `{arch}` placeholder in `config.yaml`. Per current HA developer docs, per-arch images are no longer required — a generic image name resolved through a multi-arch manifest is the recommended setup.

## What

- Replace the `build-addon` matrix with a single buildx job (`linux/amd64,linux/arm64`) pushing one `meralco-ph-addon` package, mirroring the existing standalone job.
- Dockerfile now selects the HA base image per platform via `TARGETARCH` stage aliases (HA publishes no generic multi-arch `base-python` manifest, verified against GHCR), removing the `BUILD_FROM` build-arg.
- `config.yaml`: `image: ghcr.io/rairulyle/meralco-ph-addon`.
- Delete `build.yaml` (unused now that CI doesn't pass per-arch bases); its custom OCI labels moved into the workflow metadata step.
- Update CONTRIBUTING release flow and add a CHANGELOG entry under Unreleased.

Version bump is left for the release branch per the usual flow.

## Verification

- Full local `docker build` for amd64 succeeds with the new base mapping.
- `docker build --check --platform linux/arm64` resolves the aarch64 base with no warnings.
- After the next tagged release: confirm the `meralco-ph-addon` package lists both architectures, make it public on GHCR, and verify an HA install pulls it before deprecating the old per-arch packages.