### PR TITLE
fix(ha-addon): version mismatched by updating from 2.0.2 to 2.0.3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 name: MERALCO PH
-version: "2.0.2"
+version: "2.0.3"
 slug: meralco-ph
 description: Parses MERALCO's official residential bills PDF and exposes per-kWh rates via MQTT discovery or REST API.
 url: "https://github.com/rairulyle/meralco-ph"


### PR DESCRIPTION
HA install failing from mismatched version on the config.yaml file